### PR TITLE
Revert "Fix failing CI pipeline for low disk space"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,7 @@ jobs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
       pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
-
-    # Prevent the Action workflow from failing due to low disk space
     steps:
-      - name: Free disk space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          df -h
 
       # Check out current repository
       - name: Fetch Sources


### PR DESCRIPTION
This reverts commit 9dd8894dab5597cddc4b36d65a55276728398499.

It was not needed because there is already a step for cleaning up space on the runner