### PR TITLE
Remove "verify" requirement for drafting releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
   releaseDraft:
     name: Release draft
     if: github.event_name != 'pull_request'
-    needs: [ build, test, inspectCode, verify ]
+    needs: [ build, test, inspectCode ]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Because oftentimes the verifyPlugin task consume all disk space on CI/CD runners